### PR TITLE
Remove keep alive jobs

### DIFF
--- a/.github/workflows/ap-northeast-1-workflow.yml
+++ b/.github/workflows/ap-northeast-1-workflow.yml
@@ -13,12 +13,6 @@ permissions:
 env:
   REGION: "ap-northeast-1"
 jobs:
-  workflow-keep-alive:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Flip workflow
-        uses: Chia-Network/actions/github/keep-alive@main
-
   packer_validate: # This will check the syntax for the packer file
     runs-on: [ k8s-public ] # k8s-public is used internally only. Recommend using ubuntu:latest in place of k8s-public
     container:

--- a/.github/workflows/ap-southeast-1-workflow.yml
+++ b/.github/workflows/ap-southeast-1-workflow.yml
@@ -13,12 +13,6 @@ permissions:
 env:
   REGION: "ap-southeast-1"
 jobs:
-  workflow-keep-alive:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Flip workflow
-        uses: Chia-Network/actions/github/keep-alive@main
-
   packer_validate: # This will check the syntax for the packer file
     runs-on: [ k8s-public ] # k8s-public is used internally only. Recommend using ubuntu:latest in place of k8s-public
     container:

--- a/.github/workflows/eu-west-2-workflow.yml
+++ b/.github/workflows/eu-west-2-workflow.yml
@@ -13,12 +13,6 @@ permissions:
 env:
   REGION: "eu-west-2"
 jobs:
-  workflow-keep-alive:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Flip workflow
-        uses: Chia-Network/actions/github/keep-alive@main
-
   packer_validate: # This will check the syntax for the packer file
     runs-on: [ k8s-public ] # k8s-public is used internally only. Recommend using ubuntu:latest in place of k8s-public
     container:

--- a/.github/workflows/us-east-1-workflow.yml
+++ b/.github/workflows/us-east-1-workflow.yml
@@ -13,12 +13,6 @@ permissions:
 env:
   REGION: "us-east-1"
 jobs:
-  workflow-keep-alive:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Flip workflow
-        uses: Chia-Network/actions/github/keep-alive@main
-
   packer_validate: # This will check the syntax for the packer file
     runs-on: [ k8s-public ] # k8s-public is used internally only. Recommend using ubuntu:latest in place of k8s-public
     container:

--- a/.github/workflows/us-west-2-workflow.yml
+++ b/.github/workflows/us-west-2-workflow.yml
@@ -13,12 +13,6 @@ permissions:
 env:
   REGION: "us-west-2"
 jobs:
-  workflow-keep-alive:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Flip workflow
-        uses: Chia-Network/actions/github/keep-alive@main
-
   packer_validate: # This will check the syntax for the packer file
     runs-on: [ k8s-public ] # k8s-public is used internally only. Recommend using ubuntu:latest in place of k8s-public
     container:


### PR DESCRIPTION
The keep alive workflow jobs relied on a behavior of GitHub's API that has since been changed.